### PR TITLE
Add Revit family DWG export add-in

### DIFF
--- a/ExportFamilyDWG.addin
+++ b/ExportFamilyDWG.addin
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RevitAddIns>
+  <AddIn Type="Command">
+    <Name>ExportFamilyDWG</Name>
+    <Assembly>$(AppData)\Autodesk\Revit\Addins\2024\ExportFamilyDWG.dll</Assembly>
+    <AddInId>9e317b14-2f40-4c72-9867-8b74e38c3ca5</AddInId>
+    <FullClassName>ExportFamilyDWG.ExportFamilyDWGCommand</FullClassName>
+    <VendorId>ADSK</VendorId>
+    <VendorDescription>Export families to DWG</VendorDescription>
+  </AddIn>
+</RevitAddIns>

--- a/ExportFamilyDWG/ExportFamilyDWG.csproj
+++ b/ExportFamilyDWG/ExportFamilyDWG.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="RevitAPI">
+      <HintPath>C:\Program Files\Autodesk\Revit 2024\RevitAPI.dll</HintPath>
+    </Reference>
+    <Reference Include="RevitAPIUI">
+      <HintPath>C:\Program Files\Autodesk\Revit 2024\RevitAPIUI.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+</Project>

--- a/ExportFamilyDWG/ExportFamilyDWGCommand.cs
+++ b/ExportFamilyDWG/ExportFamilyDWGCommand.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.Attributes;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Autodesk.Revit.UI.Selection;
+using System.Windows.Forms;
+
+namespace ExportFamilyDWG
+{
+    [Transaction(TransactionMode.Manual)]
+    public class ExportFamilyDWGCommand : IExternalCommand
+    {
+        public Result Execute(ExternalCommandData commandData, ref string message, ElementSet elements)
+        {
+            UIApplication uiapp = commandData.Application;
+            UIDocument uidoc = uiapp.ActiveUIDocument;
+            Document doc = uidoc.Document;
+
+            // Collect all loaded families in the document
+            IList<Family> families = new FilteredElementCollector(doc)
+                                        .OfClass(typeof(Family))
+                                        .Cast<Family>()
+                                        .ToList();
+
+            if(families.Count == 0)
+            {
+                TaskDialog.Show("Export", "No families found in the document.");
+                return Result.Cancelled;
+            }
+
+            foreach (Family fam in families)
+            {
+                using (FolderBrowserDialog dialog = new FolderBrowserDialog())
+                {
+                    dialog.Description = $"Select folder to save {fam.Name}.dwg";
+                    if (dialog.ShowDialog() != DialogResult.OK)
+                    {
+                        continue;
+                    }
+
+                    string folderPath = dialog.SelectedPath;
+                    string dwgPath = Path.Combine(folderPath, fam.Name + ".dwg");
+
+                    // Open family document for editing
+                    Document famDoc = doc.EditFamily(fam);
+
+                    // Find a 3D view to export
+                    View3D view3D = new FilteredElementCollector(famDoc)
+                                        .OfClass(typeof(View3D))
+                                        .Cast<View3D>()
+                                        .FirstOrDefault(v => !v.IsTemplate);
+                    if (view3D == null)
+                    {
+                        TaskDialog.Show("Export", $"No 3D view found for family {fam.Name}.");
+                        famDoc.Close(false);
+                        continue;
+                    }
+
+                    IList<ElementId> views = new List<ElementId> { view3D.Id };
+
+                    DWGExportOptions options = new DWGExportOptions
+                    {
+                        FileVersion = ACADVersion.R2018, // Revit 2024 default dwg version
+                        ExportOfSolids = SolidGeometry.ACIS
+                    };
+
+                    bool success = famDoc.Export(folderPath, fam.Name + ".dwg", views, options);
+                    famDoc.Close(false);
+
+                    if(!success)
+                    {
+                        TaskDialog.Show("Export", $"Failed to export {fam.Name}.");
+                    }
+                }
+            }
+
+            return Result.Succeeded;
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-- 👋 Hi, I’m @jayhuekim
-- 👀 I’m interested in dynamo and python
-- 🌱 I’m currently studing python
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# Jayhuekim Utilities
 
-<!---
-jayhuekim/jayhuekim is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+This repository contains utilities and samples for Autodesk Revit.
+
+## ExportFamilyDWG Add-in
+
+`ExportFamilyDWG` is a Revit 2024 add-in that lets you export loaded families as 3D DWG files. For each family, a folder selection window allows you to choose where the DWG will be saved. The file is saved with the family name as the filename (e.g. `FamilyName.dwg`).
+
+To build the add-in, open `ExportFamilyDWG.csproj` in Visual Studio with the Revit 2024 API assemblies referenced in the provided paths. Copy `ExportFamilyDWG.addin` and the compiled DLL to the Revit 2024 add-ins folder.


### PR DESCRIPTION
## Summary
- create ExportFamilyDWG add-in project and manifest
- implement `ExportFamilyDWGCommand` to export families to DWG
- update repository README with add-in usage

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687742b12640832b97f0834e4a33879b